### PR TITLE
Add STOPSIGNAL to ensure clean shutdown of container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,6 @@ EXPOSE 22
 
 # This will automatically start systemd
 CMD ["/usr/sbin/init"]
+
+# Shutdown systemd in container correctly
+STOPSIGNAL "RTMIN+3"


### PR DESCRIPTION
Without this `docker stop` will timeout (default 10s) and automatically kill the container. With this `docker stop` should cleanly shutdown the container.