### PR TITLE
switch to new output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         id: getprefix
         run: |
           if [ ! -z ${{ env.name }} ]; then
-            echo "::set-output name=prefix::${{ env.name }}:"
+            echo "prefix=${{ env.name }}:" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=prefix::${{ github.repository }}:"
+            echo "prefix=${{ github.repository }}:" >> $GITHUB_OUTPUT
           fi
       - name: Get other tags
         id: gettags


### PR DESCRIPTION
Check that the build is green
Background https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 